### PR TITLE
Fix pthread library linkage and add <pthread.h> header

### DIFF
--- a/src/log_module.cpp
+++ b/src/log_module.cpp
@@ -19,6 +19,8 @@
 
 #include <time.h>
 #include <string.h>
+#include <pthread.h>
+
 
 #ifndef __linux__
 #include <comutil.h>  


### PR DESCRIPTION
This pull request addresses an issue with the pthread library linkage in the SDK, which caused function declaration errors related to threading. The following changes have been made:
- Added the missing <pthread.h> header in log_module.cpp to resolve the pthread function declaration issues.
The error occurred when trying to build the library on a Raspberry Pi 5.
