### PR TITLE
add pthread include to log module

### DIFF
--- a/src/log_module.cpp
+++ b/src/log_module.cpp
@@ -19,6 +19,7 @@
 
 #include <time.h>
 #include <string.h>
+#include <pthread.h>
 
 #ifndef __linux__
 #include <comutil.h>  


### PR DESCRIPTION
Added a missing include, I am successfully able to build now. Cannot build without it. Tested on Kilted / Jazzy. 